### PR TITLE
fix: update entity ids of removed members

### DIFF
--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -114,7 +114,7 @@ export function addMember(event: MemberAdded): void {
 
         member.group = group.id
         member.identityCommitment = event.params.identityCommitment
-        member.index = group.size
+        member.index = group.numberOfLeaves
 
         member.save()
 

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -98,6 +98,16 @@ export function addMember(event: MemberAdded): void {
         const memberId = hash(
             concat(ByteArray.fromBigInt(event.params.identityCommitment), ByteArray.fromBigInt(event.params.groupId))
         )
+
+        // If there is a removed member with the same id it updates its id.
+        const removedMember = Member.load(memberId)
+
+        if (removedMember !== null) {
+            removedMember.id = hash(concat(ByteArray.fromHexString(memberId), ByteArray.fromI32(removedMember.index)))
+
+            removedMember.save()
+        }
+
         const member = new Member(memberId)
 
         log.info("Adding member '{}' in the onchain group '{}'", [member.id, group.id])
@@ -132,7 +142,7 @@ export function removeMember(event: MemberRemoved): void {
             concat(ByteArray.fromBigInt(event.params.identityCommitment), ByteArray.fromBigInt(event.params.groupId))
         )
         const member = Member.load(memberId)
-        
+
         if (member) {
             log.info("Removing member '{}' from the onchain group '{}'", [member.id, event.params.groupId.toString()])
 
@@ -145,7 +155,10 @@ export function removeMember(event: MemberRemoved): void {
 
             group.save()
 
-            log.info("Member '{}' of the onchain group '{}' has been removed", [member.id, event.params.groupId.toString()])
+            log.info("Member '{}' of the onchain group '{}' has been removed", [
+                member.id,
+                event.params.groupId.toString()
+            ])
         }
     }
 }


### PR DESCRIPTION
Updating the id of the old removed members can allow us to keep the id uniqueness and have only one `hash(id commitment + group id)` member id (the one related to the last active leaf).

Removed members ids will be equal to `hash(removedMember.id, removedMember.index)`.

@jdhyun09